### PR TITLE
feat: add failOnUnresolved option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Add `bare-import-rewrite` to `plugins` in your babel settings.
 			"modulesDir": "/node_modules",
 			"rootBaseDir": ".",
 			"alwaysRootImport": [],
-			"ignorePrefixes": ["//"]
+			"ignorePrefixes": ["//"],
+			"failOnUnresolved": false,
 		}]
 	]
 }
@@ -75,6 +76,11 @@ for `some-exception`:
 	"neverRootImport": ["some-exception"]
 }
 ```
+
+### failOnUnresolved
+
+By default an error is logged when an import could not be resolved, but it does not fail babel compilation.
+Setting this option to true will fail babel compilation with details.
 
 ### fsPath
 

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function absResolve(importPath, sourceFileName, pluginOptions = {}) {
 	});
 }
 
-function tryResolve(importPath, sourceFileName, pluginOptions) {
+function tryResolve(babelPath, importPath, sourceFileName, pluginOptions) {
 	if (whatwgUrl.parseURL(importPath) !== null) {
 		return importPath;
 	}
@@ -100,8 +100,12 @@ function tryResolve(importPath, sourceFileName, pluginOptions) {
 
 		return importPathRel;
 	} catch (error) {
-		console.error(`Could not resolve '${importPath}' in file '${sourceFileName}'.`);
-		return importPath;
+		if (pluginOptions.failOnUnresolved) {
+			throw babelPath.buildCodeFrameError(`Could not resolve '${importPath}'.`);
+		} else {
+			console.error(`Could not resolve '${importPath}' in file '${sourceFileName}'.`);
+			return importPath;
+		}
 	}
 }
 
@@ -119,7 +123,7 @@ module.exports = ({types: t}) => ({
 				return;
 			}
 
-			source.replaceWith(t.stringLiteral(tryResolve(source.node.value, file.opts.parserOpts.sourceFileName, opts)));
+			source.replaceWith(t.stringLiteral(tryResolve(path, source.node.value, file.opts.parserOpts.sourceFileName, opts)));
 		},
 		'ImportDeclaration|ExportNamedDeclaration|ExportAllDeclaration'(path, {file, opts}) {
 			const source = path.get('source');
@@ -129,7 +133,7 @@ module.exports = ({types: t}) => ({
 				return;
 			}
 
-			source.replaceWith(t.stringLiteral(tryResolve(source.node.value, file.opts.parserOpts.sourceFileName, opts)));
+			source.replaceWith(t.stringLiteral(tryResolve(path, source.node.value, file.opts.parserOpts.sourceFileName, opts)));
 		},
 	},
 });


### PR DESCRIPTION
Adds `failOnUnresolved` option to log proper error messages.

Fixes https://github.com/cfware/babel-plugin-bare-import-rewrite/issues/13