### PR TITLE
feat: Use relative path to node_modules by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ If the plugin settings object is omitted the defaults are used:
 ### modulesDir
 
 The URL path in which files from the `node_modules` directory will be published on
-the web server. This must always be an absolute URL (with or without hostname).
-Default "/node_modules".
+the web server. This must be an absolute URL if provided (with or without hostname).
+Default undefined.
 
 ### rootBaseDir
 

--- a/index.js
+++ b/index.js
@@ -80,8 +80,8 @@ function tryResolve(babelPath, importPath, sourceFileName, pluginOptions) {
 		let importPathRel = path.relative(path.dirname(sourceFileName), importPathAbs);
 		const sep = pluginOptions.fsPath === true ? path.sep : path.posix.sep;
 
-		if (isNodeModule && !fromNodeModule) {
-			const modulesDir = pluginOptions.modulesDir || (pluginOptions.fsPath === true ? nodeModules : '/node_modules');
+		const {modulesDir} = pluginOptions;
+		if (modulesDir && isNodeModule && !fromNodeModule) {
 			if (modulesDir.includes('://')) {
 				return modulesDir + (modulesDir.endsWith('/') ? '' : '/') + pathToURL(path.relative(nodeModules, importPathAbs));
 			}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.4.5",
+		"@cfware/eslint-config-node": "^0.1.0",
 		"@cfware/fake-module1": "file:fixtures/packages/fake-module1@2",
 		"@cfware/fake-module2": "file:fixtures/packages/fake-module2",
 		"@cfware/nyc": "^0.5.0",
@@ -46,5 +47,8 @@
 		"nyc": "^14.1.1",
 		"standard-version": "^6.0.1",
 		"xo": "^0.24.0"
+	},
+	"xo": {
+		"extends": "@cfware/eslint-config-node"
 	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,11 @@
 import path from 'path';
 import test from 'ava';
 import {transform} from '@babel/core';
-import plugin from '..';
+import plugin from '../index.js';
 
 const projectDir = path.resolve(__dirname, '..');
 const nodeModules = path.resolve(projectDir, 'node_modules');
+const nodeModulesRelative = path.join('.', 'node_modules');
 
 function babelTest(t, source, result, options = {}) {
 	const origError = console.error;
@@ -86,7 +87,7 @@ test('absolute resolve', t => {
 
 test('static node package', t => babelTest(t,
 	'import mod from "@cfware/fake-module1";',
-	'import mod from "/node_modules/@cfware/fake-module1/index.js";'
+	'import mod from "./node_modules/@cfware/fake-module1/index.js";'
 ));
 
 test('static package from resolve directory A', t => babelTest(t,
@@ -112,7 +113,7 @@ test('static package from resolve directory A imported by a file in resolve dire
 
 test('static package from resolve directory B imported by a file in resolve directory A', t => babelTest(t,
 	'import mod from "@cfware/fake-module1";',
-	'import mod from "/node_modules/@cfware/fake-module1/index.js";',
+	'import mod from "../../../node_modules/@cfware/fake-module1/index.js";',
 	{
 		filename: 'fixtures/my-modules/my-other-module/foo.js',
 		plugins: [[plugin, {
@@ -181,7 +182,7 @@ test('static node package to package with absolute path', t => babelTest(t,
 
 test('static node package to package with fsPath but no modulesDir specified', t => babelTest(t,
 	'import mod from "is-windows";',
-	`import mod from "${path.join(nodeModules, 'is-windows', 'index.js').replace(/\\/g, '\\\\')}";`,
+	`import mod from ".${(path.sep + path.join(nodeModulesRelative, 'is-windows', 'index.js')).replace(/\\/g, '\\\\')}";`,
 	{
 		plugins: [[plugin, {fsPath: true}]],
 		filename: 'index.js'


### PR DESCRIPTION
BREAKING CHANGE: The `modulesDir` no longer defaults to `/node_modules`.

---

CC @LarsDenBakker